### PR TITLE
Handle message change events

### DIFF
--- a/data_ai_bot/slack.py
+++ b/data_ai_bot/slack.py
@@ -24,7 +24,8 @@ def get_slack_message_event_from_event_dict(
     app: slack_bolt.App,
     event: dict
 ) -> SlackMessageEvent:
-    thread_ts = event.get('thread_ts')
+    message = event.get('message', event)
+    thread_ts = message.get('thread_ts')
     previous_message_dict_list: Sequence[dict] = []
     if thread_ts:
         result = app.client.conversations_replies(
@@ -33,10 +34,10 @@ def get_slack_message_event_from_event_dict(
         )
         previous_message_dict_list = cast(Sequence[dict], result.get('messages', []))
     return SlackMessageEvent(
-        user=event['user'],
-        text=event['text'],
-        ts=event['ts'],
-        thread_ts=thread_ts or event['ts'],
+        user=message['user'],
+        text=message['text'],
+        ts=message['ts'],
+        thread_ts=thread_ts or message['ts'],
         channel=event['channel'],
         channel_type=event.get('channel_type'),
         previous_messages=[

--- a/tests/unit_tests/slack_test.py
+++ b/tests/unit_tests/slack_test.py
@@ -90,6 +90,31 @@ class TestGetSlackMessageEventFromEventDict:
         )
         assert message_event.previous_messages == ['previous_text_1']
 
+    def test_should_extract_from_message_changed_event(
+        self,
+        slack_app_mock: MagicMock
+    ):
+        message_event = get_slack_message_event_from_event_dict(
+            app=slack_app_mock,
+            event={
+                'ts': 'ts_1',
+                'channel': 'channel_1',
+                'channel_type': 'channel_type_1',
+                'message': {
+                    'ts': 'ts_2',
+                    'thread_ts': 'thread_ts_1',
+                    'user': 'user_1',
+                    'text': 'text_1'
+                }
+            }
+        )
+        assert message_event.ts == 'ts_2'
+        assert message_event.thread_ts == 'thread_ts_1'
+        assert message_event.channel == 'channel_1'
+        assert message_event.channel_type == 'channel_type_1'
+        assert message_event.user == 'user_1'
+        assert message_event.text == 'text_1'
+
 
 class TestGetSlackMrkdwnForMarkdown:
     def test_should_not_convert_simple_text(self):


### PR DESCRIPTION
message changed events have some of the otherwise required fields with the `message` field (as well as `previous_message`) but not at the root level.