### PR TITLE
Handle long messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,16 +84,16 @@ build:
 	$(DOCKER_COMPOSE) build
 
 flake8:
-	$(DOCKER_COMPOSE) run --rm data-ai-bot tests \
-		python3 -m flake8 data_ai_bot
+	$(DOCKER_COMPOSE) run --rm data-ai-bot \
+		python3 -m flake8 data_ai_bot tests
 
 pylint:
-	$(DOCKER_COMPOSE) run --rm data-ai-bot tests \
-		python3 -m pylint data_ai_bot
+	$(DOCKER_COMPOSE) run --rm data-ai-bot \
+		python3 -m pylint data_ai_bot tests
 
 mypy:
-	$(DOCKER_COMPOSE) run --rm data-ai-bot tests \
-		python3 -m mypy --check-untyped-defs data_ai_bot
+	$(DOCKER_COMPOSE) run --rm data-ai-bot \
+		python3 -m mypy --check-untyped-defs data_ai_bot tests
 
 lint: flake8 pylint mypy
 

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,13 @@ dev-venv: venv-create dev-install
 
 
 dev-flake8:
-	$(PYTHON) -m flake8 data_ai_bot
+	$(PYTHON) -m flake8 data_ai_bot tests
 
 dev-pylint:
-	$(PYTHON) -m pylint data_ai_bot
+	$(PYTHON) -m pylint data_ai_bot tests
 
 dev-mypy:
-	$(PYTHON) -m mypy --check-untyped-defs data_ai_bot
+	$(PYTHON) -m mypy --check-untyped-defs data_ai_bot tests
 
 dev-lint: dev-flake8 dev-pylint dev-mypy
 
@@ -84,15 +84,15 @@ build:
 	$(DOCKER_COMPOSE) build
 
 flake8:
-	$(DOCKER_COMPOSE) run --rm data-ai-bot \
+	$(DOCKER_COMPOSE) run --rm data-ai-bot tests \
 		python3 -m flake8 data_ai_bot
 
 pylint:
-	$(DOCKER_COMPOSE) run --rm data-ai-bot \
+	$(DOCKER_COMPOSE) run --rm data-ai-bot tests \
 		python3 -m pylint data_ai_bot
 
 mypy:
-	$(DOCKER_COMPOSE) run --rm data-ai-bot \
+	$(DOCKER_COMPOSE) run --rm data-ai-bot tests \
 		python3 -m mypy --check-untyped-defs data_ai_bot
 
 lint: flake8 pylint mypy

--- a/data_ai_bot/cli.py
+++ b/data_ai_bot/cli.py
@@ -27,6 +27,7 @@ from data_ai_bot.slack import (
 )
 from data_ai_bot.telemetry import configure_otlp_if_enabled
 from data_ai_bot.tools.resolver import ConfigToolResolver
+from data_ai_bot.utils.dummy_text import DUMMY_TEXT_4K
 
 
 LOGGER = logging.getLogger(__name__)
@@ -118,6 +119,10 @@ class SlackChatApp:
     echo_message: bool = False
 
     def get_agent_response_message(self, message_event: SlackMessageEvent) -> str:
+        text = message_event.text
+        last_word = text.rsplit(' ')[-1]
+        if last_word == 'TEST_LONG_TEXT':
+            return DUMMY_TEXT_4K
         return self.agent_factory().run(
             get_agent_message(
                 message_event=message_event

--- a/data_ai_bot/cli.py
+++ b/data_ai_bot/cli.py
@@ -124,6 +124,8 @@ class SlackChatApp:
         last_word = text.rsplit(' ')[-1]
         if last_word == 'TEST_LONG_TEXT':
             return DUMMY_TEXT_4K
+        if last_word == 'TEST_LONG_CODE':
+            return f'```\n{DUMMY_TEXT_4K}\n```'
         return self.agent_factory().run(
             get_agent_message(
                 message_event=message_event

--- a/data_ai_bot/cli.py
+++ b/data_ai_bot/cli.py
@@ -22,6 +22,7 @@ from data_ai_bot.config import (
 from data_ai_bot.slack import (
     SlackMessageEvent,
     get_message_age_in_seconds_from_event_dict,
+    get_slack_blocks_for_mrkdwn,
     get_slack_message_event_from_event_dict,
     get_slack_mrkdwn_for_markdown
 )
@@ -163,13 +164,9 @@ class SlackChatApp:
             self.slack_app.client.chat_postMessage(
                 text=response_message,
                 mrkdwn=True,
-                blocks=[{
-                    'type': 'section',
-                    'text': {
-                        'type': 'mrkdwn',
-                        'text': response_message_mrkdwn
-                    }
-                }],
+                blocks=get_slack_blocks_for_mrkdwn(
+                    response_message_mrkdwn
+                ),
                 channel=message_event.channel,
                 thread_ts=message_event.thread_ts
             )

--- a/data_ai_bot/cli.py
+++ b/data_ai_bot/cli.py
@@ -117,6 +117,16 @@ class SlackChatApp:
     slack_app: slack_bolt.App
     echo_message: bool = False
 
+    def get_agent_response_message(self, message_event: SlackMessageEvent) -> str:
+        return self.agent_factory().run(
+            get_agent_message(
+                message_event=message_event
+            ),
+            additional_args={
+                'previous_messages': message_event.previous_messages
+            }
+        )
+
     def handle_message(self, event: dict, say: Say):
         try:
             message_event = get_slack_message_event_from_event_dict(
@@ -136,13 +146,8 @@ class SlackChatApp:
                     f'Hi <@{message_event.user}>! You said: {message_event.text}',
                     thread_ts=message_event.thread_ts
                 )
-            response_message = self.agent_factory().run(
-                get_agent_message(
-                    message_event=message_event
-                ),
-                additional_args={
-                    'previous_messages': message_event.previous_messages
-                }
+            response_message = self.get_agent_response_message(
+                message_event=message_event
             )
             LOGGER.info('response_message: %r', response_message)
             response_message_mrkdwn = get_slack_mrkdwn_for_markdown(

--- a/data_ai_bot/cli.py
+++ b/data_ai_bot/cli.py
@@ -3,7 +3,7 @@ from io import BytesIO
 import logging
 import os
 import traceback
-from typing import Callable, Optional, Sequence
+from typing import Callable, Optional, Sequence, cast
 
 import slack_bolt
 from slack_bolt.adapter.socket_mode import SocketModeHandler
@@ -170,7 +170,7 @@ class SlackChatApp:
             self.slack_app.client.chat_postMessage(
                 text=response_message,
                 mrkdwn=True,
-                blocks=blocks,
+                blocks=cast(Sequence[dict], blocks),
                 channel=message_event.channel,
                 thread_ts=message_event.thread_ts
             )

--- a/data_ai_bot/slack.py
+++ b/data_ai_bot/slack.py
@@ -56,3 +56,13 @@ def get_message_age_in_seconds_from_event_dict(
 
 def get_slack_mrkdwn_for_markdown(markdown: str) -> str:
     return SlackMarkdownConverter().convert(markdown)
+
+
+def get_slack_blocks_for_mrkdwn(mrkdwn: str) -> Sequence[dict]:
+    return [{
+        'type': 'section',
+        'text': {
+            'type': 'mrkdwn',
+            'text': mrkdwn
+        }
+    }]

--- a/data_ai_bot/slack.py
+++ b/data_ai_bot/slack.py
@@ -24,6 +24,16 @@ CODE_BLOCK_RE = re.compile(
 )
 
 
+class BlockTextTypedDict(TypedDict):
+    type: str  # e.g. 'mrkdwn'
+    text: str
+
+
+class BlockTypedDict(TypedDict):
+    type: str  # e.g. 'section'
+    text: BlockTextTypedDict
+
+
 @dataclass(frozen=True)
 class SlackMessageEvent:
     user: str
@@ -165,7 +175,7 @@ def iter_split_mrkdwn(mrkdwn: str, max_length: int) -> Iterable[str]:
 def get_slack_blocks_for_mrkdwn(
     mrkdwn: str,
     max_block_length: int = DEFAULT_MAX_BLOCK_LENGTH
-) -> Sequence[dict]:
+) -> Sequence[BlockTypedDict]:
     return [
         {
             'type': 'section',
@@ -209,13 +219,13 @@ def get_file_dict_from_code_block(
 def get_replacement_block_and_file_for_too_long_code_block(
     too_long_code_block: str,
     file_no: int
-) -> tuple[dict, FileTypedDict]:
+) -> tuple[BlockTypedDict, FileTypedDict]:
     file_dict: FileTypedDict = get_file_dict_from_code_block(
         too_long_code_block,
         file_no=file_no
     )
     filename = file_dict['filename']
-    block = {
+    block: BlockTypedDict = {
         'type': 'section',
         'text': {
             'type': 'mrkdwn',
@@ -228,7 +238,7 @@ def get_replacement_block_and_file_for_too_long_code_block(
 def get_slack_blocks_and_files_for_mrkdwn(
     mrkdwn: str,
     max_block_length: int = DEFAULT_MAX_BLOCK_LENGTH
-) -> tuple[Sequence[dict], Sequence[FileTypedDict]]:
+) -> tuple[Sequence[BlockTypedDict], Sequence[FileTypedDict]]:
     candidate_blocks = get_slack_blocks_for_mrkdwn(mrkdwn, max_block_length=max_block_length)
     files: list[FileTypedDict] = []
     final_blocks = []

--- a/data_ai_bot/slack.py
+++ b/data_ai_bot/slack.py
@@ -109,8 +109,11 @@ def iter_split_mrkdwn(mrkdwn: str, max_length: int) -> Iterable[str]:
         else:
             if chunk:
                 yield chunk
-            yield from iter_split_long_paragraph(para, max_length)
-            chunk = ''
+            if len(para) > max_length:
+                yield from iter_split_long_paragraph(para, max_length)
+                chunk = ''
+            else:
+                chunk = para
     if chunk:
         yield chunk
 

--- a/data_ai_bot/slack.py
+++ b/data_ai_bot/slack.py
@@ -34,6 +34,17 @@ class BlockTypedDict(TypedDict):
     text: BlockTextTypedDict
 
 
+class FileTypedDict(TypedDict):
+    filename: str
+    content: bytes
+
+
+FILE_EXT_BY_LANGUAGE: Mapping[str, str] = {
+    'python': 'py',
+    'text': 'txt'
+}
+
+
 @dataclass(frozen=True)
 class SlackMessageEvent:
     user: str
@@ -186,17 +197,6 @@ def get_slack_blocks_for_mrkdwn(
         }
         for block_mrkdwn in iter_split_mrkdwn(mrkdwn, max_length=max_block_length)
     ]
-
-
-class FileTypedDict(TypedDict):
-    filename: str
-    content: bytes
-
-
-FILE_EXT_BY_LANGUAGE: Mapping[str, str] = {
-    'python': 'py',
-    'text': 'txt'
-}
 
 
 def get_file_dict_from_code_block(

--- a/data_ai_bot/slack.py
+++ b/data_ai_bot/slack.py
@@ -229,7 +229,7 @@ def get_replacement_block_and_file_for_too_long_code_block(
         'type': 'section',
         'text': {
             'type': 'mrkdwn',
-            'text': f'See {filename}'
+            'text': f'See `{filename}`'
         }
     }
     return block, file_dict

--- a/data_ai_bot/utils/dummy_text.py
+++ b/data_ai_bot/utils/dummy_text.py
@@ -1,0 +1,16 @@
+import textwrap
+
+
+# 447 characters
+DUMMY_TEXT_1 = textwrap.dedent(
+    '''
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+    ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+    laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+    voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+    non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    '''
+).replace('\n', ' ')
+
+
+DUMMY_TEXT_4K = '\n\n'.join([DUMMY_TEXT_1] * 9)

--- a/data_ai_bot/utils/dummy_text.py
+++ b/data_ai_bot/utils/dummy_text.py
@@ -10,7 +10,7 @@ DUMMY_TEXT_1 = textwrap.dedent(
     voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
     non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     '''
-).replace('\n', ' ')
+).strip().replace('\n', ' ')
 
 
 DUMMY_TEXT_4K = '\n\n'.join([DUMMY_TEXT_1] * 9)

--- a/tests/unit_tests/slack_test.py
+++ b/tests/unit_tests/slack_test.py
@@ -163,6 +163,16 @@ class TestIterSplitMrkdwn:
             '12345 12345'
         ]
 
+    def test_should_not_split_next_lines_before_hitting_max_length(self):
+        assert list(iter_split_mrkdwn(
+            '12345\n12345 12345\n12345 12345',
+            max_length=12
+        )) == [
+            '12345',
+            '12345 12345',
+            '12345 12345'
+        ]
+
     def test_should_prefer_splitting_at_paragraph_boundaries_if_necessary(self):
         assert list(iter_split_mrkdwn('12345\n12345\n\n12345', max_length=12)) == [
             '12345\n12345',

--- a/tests/unit_tests/slack_test.py
+++ b/tests/unit_tests/slack_test.py
@@ -277,7 +277,7 @@ class TestGetSlackBlocksAndFilesForMrkdwn:
             'type': 'section',
             'text': {
                 'type': 'mrkdwn',
-                'text': 'See file_1.py'
+                'text': 'See `file_1.py`'
             }
         }]
         assert files == [{

--- a/tests/unit_tests/slack_test.py
+++ b/tests/unit_tests/slack_test.py
@@ -153,6 +153,17 @@ class TestIterSplitMrkdwn:
             '12345'
         ]
 
+    def test_not_should_split_lines_if_within_max_length(self):
+        assert list(iter_split_mrkdwn('12345\n12345 12345', max_length=100)) == [
+            '12345\n12345 12345'
+        ]
+
+    def test_should_split_at_line_boundaries_if_necessary(self):
+        assert list(iter_split_mrkdwn('12345\n12345 12345', max_length=12)) == [
+            '12345',
+            '12345 12345'
+        ]
+
 
 class TestGetSlackBlocksForMrkdwn:
     def test_should_convert_simple_message(self):

--- a/tests/unit_tests/slack_test.py
+++ b/tests/unit_tests/slack_test.py
@@ -4,9 +4,13 @@ import pytest
 
 from data_ai_bot.slack import (
     SlackMessageEvent,
+    get_slack_blocks_for_mrkdwn,
     get_slack_message_event_from_event_dict,
     get_slack_mrkdwn_for_markdown
 )
+
+
+TEXT_1 = 'Text 1'
 
 
 MINIMAL_DIRECT_MESSAGE_SLACK_EVENT_DICT_1 = {
@@ -128,3 +132,14 @@ class TestGetSlackMrkdwnForMarkdown:
 
     def test_should_convert_markdown_link_to_slack_link(self):
         assert get_slack_mrkdwn_for_markdown('[Link Text](Link URL)') == '<Link URL|Link Text>'
+
+
+class TestGetSlackBlocksForMrkdwn:
+    def test_should_convert_simple_message(self):
+        assert get_slack_blocks_for_mrkdwn(TEXT_1) == [{
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': TEXT_1
+            }
+        }]

--- a/tests/unit_tests/slack_test.py
+++ b/tests/unit_tests/slack_test.py
@@ -164,6 +164,11 @@ class TestIterSplitMrkdwn:
             '12345 12345'
         ]
 
+    def test_should_prefer_splitting_at_paragraph_boundaries_if_necessary(self):
+        assert list(iter_split_mrkdwn('12345\n12345\n\n12345', max_length=12)) == [
+            '12345\n12345',
+            '12345'
+        ]
 
 class TestGetSlackBlocksForMrkdwn:
     def test_should_convert_simple_message(self):

--- a/tests/unit_tests/slack_test.py
+++ b/tests/unit_tests/slack_test.py
@@ -169,6 +169,15 @@ class TestIterSplitMrkdwn:
             '12345'
         ]
 
+    def test_should_not_split_next_paragraphs_before_hitting_max_length(self):
+        assert list(iter_split_mrkdwn(
+            '12345\n12345\n\n12345\n\n12345',
+            max_length=12
+        )) == [
+            '12345\n12345',
+            '12345\n\n12345'
+        ]
+
 
 class TestGetSlackBlocksForMrkdwn:
     def test_should_convert_simple_message(self):

--- a/tests/unit_tests/slack_test.py
+++ b/tests/unit_tests/slack_test.py
@@ -8,6 +8,7 @@ import data_ai_bot.slack as slack_module
 from data_ai_bot.slack import (
     DEFAULT_MAX_BLOCK_LENGTH,
     SlackMessageEvent,
+    get_slack_blocks_and_files_for_mrkdwn,
     get_slack_blocks_for_mrkdwn,
     get_slack_message_event_from_event_dict,
     get_slack_mrkdwn_for_markdown,
@@ -258,3 +259,28 @@ class TestGetSlackBlocksForMrkdwn:
             f'{TEXT_1} {TEXT_2}',
             max_length=DEFAULT_MAX_BLOCK_LENGTH
         )
+
+
+class TestGetSlackBlocksAndFilesForMrkdwn:
+    def test_should_convert_simple_message_without_files(self):
+        assert get_slack_blocks_and_files_for_mrkdwn(TEXT_1) == (
+            get_slack_blocks_for_mrkdwn(TEXT_1),
+            []
+        )
+
+    def test_should_convert_long_code_block_to_file(self):
+        blocks, files = get_slack_blocks_and_files_for_mrkdwn(
+            '```python\nprint("hello")\nprint("world")\n```',
+            max_block_length=10
+        )
+        assert blocks == [{
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': 'See file_1.py'
+            }
+        }]
+        assert files == [{
+            'filename': 'file_1.py',
+            'content': b'print("hello")\nprint("world")\n'
+        }]

--- a/tests/unit_tests/slack_test.py
+++ b/tests/unit_tests/slack_test.py
@@ -12,7 +12,6 @@ from data_ai_bot.slack import (
     get_slack_mrkdwn_for_markdown,
     iter_split_mrkdwn
 )
-from data_ai_bot.utils.dummy_text import DUMMY_TEXT_4K
 
 
 TEXT_1 = 'Text 1'
@@ -169,6 +168,7 @@ class TestIterSplitMrkdwn:
             '12345\n12345',
             '12345'
         ]
+
 
 class TestGetSlackBlocksForMrkdwn:
     def test_should_convert_simple_message(self):

--- a/tests/unit_tests/tools/resolver_test.py
+++ b/tests/unit_tests/tools/resolver_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 import pytest
 
 from data_ai_bot.config import (
@@ -58,7 +59,7 @@ class TestConfigToolResolver:
 
     def test_should_resolve_get_joke(self):
         tool = DEFAULT_CONFIG_TOOL_RESOLVER.get_tool_by_name('get_joke')
-        assert tool == get_joke
+        assert tool == get_joke  # pylint: disable=comparison-with-callable
 
     def test_should_resolve_get_docmap_by_manuscript_id(self):
         tool = DEFAULT_CONFIG_TOOL_RESOLVER.get_tool_by_name('get_docmap_by_manuscript_id')
@@ -99,7 +100,7 @@ class TestConfigToolResolver:
             )
         )
         tool = resolver.get_tool_by_name('new_name')
-        assert tool == get_joke
+        assert tool == get_joke  # pylint: disable=comparison-with-callable
         assert tool.name == 'new_name'
         assert tool.description == 'New description'
 


### PR DESCRIPTION
Avoids errors like these:

Failed to process request due to:
> SlackApiError("The request to the Slack API failed. (url: https://slack.com/api/chat.postMessage)\nThe server responded with: {'ok': False, 'error': 'invalid_blocks', 'errors': ['failed to match all allowed schemas [json-pointer:/blocks/0/text]', 'must be less than 3001 characters [json-pointer:/blocks/0/text/text]'], 'response_metadata': {'messages': ['[ERROR] failed to match all allowed schemas [json-pointer:/blocks/0/text]', '[ERROR] must be less than 3001 characters [json-pointer:/blocks/0/text/text]']}}")

Instead long blocks will get split into separate blocks.
Code blocks won't get split. If a single code block is too long, it will get turned into a file upload instead.

One can test the behaviour by sending `TEST_LONG_TEXT` or `TEST_LONG_CODE` as the last word to the AI bot.